### PR TITLE
Fixed NestedContent initially displaying conditional fields that should be hidden

### DIFF
--- a/ConditionalDisplayers/App_Plugins/ConditionalDisplayers/propertyeditors/checkbox/checkbox.controller.js
+++ b/ConditionalDisplayers/App_Plugins/ConditionalDisplayers/propertyeditors/checkbox/checkbox.controller.js
@@ -9,12 +9,6 @@ function cdCheckboxController($scope, editorState, cdSharedLogic) {
         var parentPropertyAlias = $scope.model.alias.slice(0, -$scope.model.propertyAlias.length);
     }
 
-    $scope.$watch("renderModel.value", function (newVal) {
-        $scope.model.value = newVal === true ? "1" : "0";
-
-        $scope.runDisplayLogic();
-    });
-
     $scope.clicked = function () {
         $scope.renderModel.value = !$scope.renderModel.value;
     };
@@ -29,6 +23,17 @@ function cdCheckboxController($scope, editorState, cdSharedLogic) {
             }
         }
     };
+
+    var renderModelWatchUnsubscribe = $scope.$watch("renderModel.value", function (newVal) {
+        $scope.model.value = newVal === true ? "1" : "0";
+
+        $scope.runDisplayLogic();
+    });
+
+    // update the visible fields on changes from NestedContent
+    var formSubmittingUnsubscribe = $scope.$on("formSubmitting", $scope.runDisplayLogic);
+    var ncSyncValUnsubscribe = $scope.$on("ncSyncVal", $scope.runDisplayLogic);
+    $(document).on("click", ".umb-nested-content__header-bar", $scope.runDisplayLogic)
 
     function setupViewModel() {
         $scope.renderModel = {
@@ -57,4 +62,10 @@ function cdCheckboxController($scope, editorState, cdSharedLogic) {
 
     setupViewModel();
 
+    $scope.$on("$destroy", function () {
+        renderModelWatchUnsubscribe();
+        formSubmittingUnsubscribe();
+        ncSyncValUnsubscribe();
+        $(document).off("click", ".umb-nested-content__header-bar", $scope.runDisplayLogic);
+    });
 }

--- a/ConditionalDisplayers/App_Plugins/ConditionalDisplayers/propertyeditors/dropdownFlexible/dropdownFlexible.controller.js
+++ b/ConditionalDisplayers/App_Plugins/ConditionalDisplayers/propertyeditors/dropdownFlexible/dropdownFlexible.controller.js
@@ -30,6 +30,10 @@ angular.module("umbraco").controller("Our.Umbraco.ConditionalDisplayers.Dropdown
             }
         };
 
+        // update the visible fields on changes from NestedContent
+        var formSubmittingUnsubscribe = $scope.$on("formSubmitting", $scope.runDisplayLogic);
+        var ncSyncValUnsubscribe = $scope.$on("ncSyncVal", $scope.runDisplayLogic);
+        $(document).on("click", ".umb-nested-content__header-bar", $scope.runDisplayLogic)
 
         function convertArrayToDictionaryArray(model) {
             //now we need to format the items in the dictionary because we always want to have an array
@@ -88,6 +92,10 @@ angular.module("umbraco").controller("Our.Umbraco.ConditionalDisplayers.Dropdown
         }
         $scope.runDisplayLogic();
 
-
+        $scope.$on("$destroy", function () {
+            formSubmittingUnsubscribe();
+            ncSyncValUnsubscribe();
+            $(document).off("click", ".umb-nested-content__header-bar", $scope.runDisplayLogic);
+        });
     });
 

--- a/UmbracoV10/App_Plugins/ConditionalDisplayers/propertyeditors/checkbox/checkbox.controller.js
+++ b/UmbracoV10/App_Plugins/ConditionalDisplayers/propertyeditors/checkbox/checkbox.controller.js
@@ -9,12 +9,6 @@ function cdCheckboxController($scope, editorState, cdSharedLogic) {
         var parentPropertyAlias = $scope.model.alias.slice(0, -$scope.model.propertyAlias.length);
     }
 
-    $scope.$watch("renderModel.value", function (newVal) {
-        $scope.model.value = newVal === true ? "1" : "0";
-
-        $scope.runDisplayLogic();
-    });
-
     $scope.clicked = function () {
         $scope.renderModel.value = !$scope.renderModel.value;
     };
@@ -29,6 +23,17 @@ function cdCheckboxController($scope, editorState, cdSharedLogic) {
             }
         }
     };
+
+    var renderModelWatchUnsubscribe = $scope.$watch("renderModel.value", function (newVal) {
+        $scope.model.value = newVal === true ? "1" : "0";
+
+        $scope.runDisplayLogic();
+    });
+
+    // update the visible fields on changes from NestedContent
+    var formSubmittingUnsubscribe = $scope.$on("formSubmitting", $scope.runDisplayLogic);
+    var ncSyncValUnsubscribe = $scope.$on("ncSyncVal", $scope.runDisplayLogic);
+    $(document).on("click", ".umb-nested-content__header-bar", $scope.runDisplayLogic)
 
     function setupViewModel() {
         $scope.renderModel = {
@@ -57,4 +62,10 @@ function cdCheckboxController($scope, editorState, cdSharedLogic) {
 
     setupViewModel();
 
+    $scope.$on("$destroy", function () {
+        renderModelWatchUnsubscribe();
+        formSubmittingUnsubscribe();
+        ncSyncValUnsubscribe();
+        $(document).off("click", ".umb-nested-content__header-bar", $scope.runDisplayLogic);
+    });
 }

--- a/UmbracoV10/App_Plugins/ConditionalDisplayers/propertyeditors/dropdownFlexible/dropdownFlexible.controller.js
+++ b/UmbracoV10/App_Plugins/ConditionalDisplayers/propertyeditors/dropdownFlexible/dropdownFlexible.controller.js
@@ -30,6 +30,10 @@ angular.module("umbraco").controller("Our.Umbraco.ConditionalDisplayers.Dropdown
             }
         };
 
+        // update the visible fields on changes from NestedContent
+        var formSubmittingUnsubscribe = $scope.$on("formSubmitting", $scope.runDisplayLogic);
+        var ncSyncValUnsubscribe = $scope.$on("ncSyncVal", $scope.runDisplayLogic);
+        $(document).on("click", ".umb-nested-content__header-bar", $scope.runDisplayLogic)
 
         function convertArrayToDictionaryArray(model) {
             //now we need to format the items in the dictionary because we always want to have an array
@@ -88,6 +92,10 @@ angular.module("umbraco").controller("Our.Umbraco.ConditionalDisplayers.Dropdown
         }
         $scope.runDisplayLogic();
 
-
+        $scope.$on("$destroy", function () {
+            formSubmittingUnsubscribe();
+            ncSyncValUnsubscribe();
+            $(document).off("click", ".umb-nested-content__header-bar", $scope.runDisplayLogic);
+        });
     });
 


### PR DESCRIPTION
I noticed that conditional fields within NestedContent aren't shown or hidden correctly on first load, as they are hidden on the page.

[ConditionalDisplayers-NestedContent-showhide.webm](https://user-images.githubusercontent.com/1691808/180189210-ced92e87-0d4a-46d1-917d-87e56cb17d80.webm)
 
I've added some extra listeners to the angular controllers to call the `runDisplayLogic` method when the panels are shown or updated.

I also made sure the $watch and $on subscriptions were disposed when the editors are destroyed.