### PR TITLE
Added umbraco-marketplace.json and project URL

### DIFF
--- a/ConditionalDisplayers/ConditionalDisplayers.csproj
+++ b/ConditionalDisplayers/ConditionalDisplayers.csproj
@@ -8,15 +8,16 @@
         <Product>Conditional Displayers</Product>
         <PackageTags>umbraco property editor backoffice condition display umbraco-marketplace</PackageTags>
         <AssemblyName>Our.Umbraco.ConditionalDisplayers</AssemblyName>
-	<GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-	<Version>3.2.1</Version>
-	<Authors>Mario Lopez</Authors>
-	<PackageIcon>koben_logo.png</PackageIcon>
-	<PackageReleaseNotes>Compatible with Umbraco 9</PackageReleaseNotes>
-	<RepositoryUrl>https://github.com/skartknet/ConditionalDisplayers</RepositoryUrl>
-	<PackageLicenseExpression>MIT</PackageLicenseExpression>
-	<IsPackable>true</IsPackable>
-	<PackageReadmeFile>README.md</PackageReadmeFile>
+        <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
+        <Version>3.2.1</Version>
+        <Authors>Mario Lopez</Authors>
+        <PackageIcon>koben_logo.png</PackageIcon>
+        <PackageReleaseNotes>Compatible with Umbraco 9</PackageReleaseNotes>
+        <PackageProjectUrl>https://github.com/skartknet/ConditionalDisplayers</PackageProjectUrl>
+        <RepositoryUrl>https://github.com/skartknet/ConditionalDisplayers</RepositoryUrl>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <IsPackable>true</IsPackable>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 
 

--- a/ConditionalDisplayers/umbraco-marketplace.json
+++ b/ConditionalDisplayers/umbraco-marketplace.json
@@ -1,0 +1,5 @@
+{
+    "Category": "Editor Tools",
+    "LicenseTypes": [ "Free" ],
+    "PackageType": "Package"
+  }


### PR DESCRIPTION
Hi @skartknet - I noted you'd listed this package on the Umbraco marketplace, so firstly, thanks for taking the time to do that.  I noticed though that we only have the details collected from NuGet for the package... which is fine, but to help it to be found more easily it's possible to provide additional information, as is discussed [here](https://marketplace.umbraco.com/listing).

To get started with this I've created this PR, which will at least ensure your package is listed under what looks to be the appropriate category.  You can add more, like more tags, links, or extended descriptions and readme information.  I hope that's useful for you.

In order to use this, as well as merging so it's found in the root of the repository, the NuGet package will be updated on the next release to have a `ProjectUrl` defined.  With that in place, when synchronising the data for NuGet we can follow that link for your project to find this file, and load the additional data.
