### PR TITLE
Proposed Properties and Prevalues Refinement

### DIFF
--- a/ConditionalDisplayers/App_Plugins/ConditionalDisplayers/package.manifest
+++ b/ConditionalDisplayers/App_Plugins/ConditionalDisplayers/package.manifest
@@ -2,8 +2,8 @@
   "propertyEditors": [
     {
       "alias": "Our.Umbraco.CdCheckbox",
-      "name": "Checkbox Conditional Displayer",
-      "icon": "icon-code",
+      "name": "[Skartknet] Conditional Checkbox",
+      "icon": "icon-circle-dotted-active",
       "group": "Conditional Displayers",
       "editor": {
         "view": "~/App_Plugins/ConditionalDisplayers/propertyeditors/checkbox/checkbox.html"
@@ -11,19 +11,20 @@
       "prevalues": {
         "fields": [
           {
-            "label": "Default value",
+            "label": "Initial state",
+            "description": "The initial state for the checkbox for new items and before the editor changes it.",
             "key": "default",
             "view": "boolean"
           },
           {
             "label": "Show if checked",
-            "description": "Enter the aliases of the properties to show if the checkbox if checked (comma separated)",
+            "description": "Enter the aliases of the properties to show when the checkbox is checked<br />*(multiple aliases must be comma separated without space)*",
             "key": "showIfChecked",
             "view": "textstring"
           },
           {
             "label": "Show if unchecked",
-            "description": "Enter the aliases of the properties to show if the checkbox if unchecked (comma separated)",
+            "description": "Enter the aliases of the properties to show when the checkbox is unchecked<br />*(multiple aliases must be comma separated without space)*",
             "key": "showIfUnchecked",
             "view": "textstring"
           }
@@ -32,8 +33,8 @@
     },
     {
       "alias": "Our.Umbraco.CdDropdownFlexible",
-      "name": "Dropdown Conditional Displayer",
-      "icon": "icon-code",
+      "name": "[Skartknet] Conditional Dropdown",
+      "icon": "icon-filter-arrows",
       "group": "Conditional Displayers",
       "editor": {
         "view": "~/App_Plugins/ConditionalDisplayers/propertyeditors/dropdownFlexible/dropdownFlexible.html"
@@ -42,12 +43,13 @@
         "fields": [
           {
             "label": "Add prevalue",
-            "description": "Add, remove or sort values for the list.",
+            "description": "Add, remove or sort values for the conditional list.<br />*(multiple aliases must be comma separated without space)*",
             "key": "items",
             "view": "/App_Plugins/ConditionalDisplayers/prevalueeditors/cdMultivalues.html"
           },
           {
             "label": "Default value",
+            "description": "Type the value name from the list created above to be the initial default selection.<br/>*(Optional)*",
             "key": "default",
             "view": "textstring"
           }

--- a/ConditionalDisplayers/App_Plugins/ConditionalDisplayers/prevalueeditors/cdMultivalues.html
+++ b/ConditionalDisplayers/App_Plugins/ConditionalDisplayers/prevalueeditors/cdMultivalues.html
@@ -1,4 +1,4 @@
-<div class="umb-property-editor umb-prevalues-multivalues" ng-controller="Our.Umbraco.ConditionalDisplayers.cdMultiValuesController">
+<div class="umb-property-editor umb-prevalues-multivalues cd-prevalues-editor" ng-controller="Our.Umbraco.ConditionalDisplayers.cdMultiValuesController">
 
     <div class="control-group cd-prevalues-multivalues">
         <div>
@@ -6,11 +6,11 @@
             <input overlay-submit-on-enter="false" name="newItem" focus-when="{{focusOnNew}}" ng-keydown="createNew($event)" type="text" ng-model="newItem.value" val-highlight="{{hasError}}" />
         </div>
         <div>
-            <strong>Show if selected <br /><small>(separate by comma)</small></strong>
+            <strong>Show when selected</strong>
             <input type="text" ng-model="newItem.show" val-server="item_{{$index}}" placeholder="Properties' aliases" />
         </div>
         <div>
-            <strong>Hide if selected <br /><small>(separate by comma)</small></strong>
+            <strong>Hide when selected</strong>
             <input type="text" ng-model="newItem.hide" val-server="item_{{$index}}" placeholder="Properties' aliases" />
         </div>
         <div class="align-bottom">


### PR DESCRIPTION
Some proposed refinements that this PR addresses:

**1. Changed the icons from the generic 'code' icon so they are different between the 2 properties and distinguishable from one another.**
- Checkbox using the circle dotted tick, so it’s not similar to Built-In Umbraco Toggle
- Dropdown using Filter Arrows as I haven’t seen it used anywhere so far and kind of descriptive of the property purpose.

**2. Changed the name of the properties for few reasons:**
- _(inspired from contentment naming convention) - using brackets to 'brand' the properties and make them uniquely distinguishable_
- To keep both properties together and close to each other amongst the many different properties in some cases
- Simplicity and easy to read and find

**3. Checkbox “Default Value” prevalue:**
- Changed the label from “Default value” to “Initial State” to match the Umbraco Toggle label
- Added kind of a similar description as the Umbraco Toggle’s ‘Initial State’ description with some changes to the wordings for simplicity

**4. “Show if checked” and “Show if unchecked”**
- Fixed a grammar mistake “…if the checkbox **if** checked…” and “…if the checkbox **if** unchecked…”
- Also changed it to “…**when** the checkbox **is** checked…” and “…**when** the checkbox **is** unchecked…”
- Made the ‘Comma separated’ statement in italic and in a new line, then iterated that there should be no space.

**5. “Dropdown prevalues”**
- Added the ‘Comma separated’ statement to the description with some modifications
- Removed “(separated by comma)” from their current place for a cleaner representation, given we added it to the description of the property.
- Changed “Show if selected” to “Show when selected” and “Hide if selected” to “Hide when selected”
- Added the word “conditional” to the description so it’s distinguishable from standard dropdown prevalue
- Added a description to the ‘Default value’