### PR TITLE
Issue #10 + converted the checkbox to use the uui component

### DIFF
--- a/ConditionalDisplayers/App_Plugins/ConditionalDisplayers/package.manifest
+++ b/ConditionalDisplayers/App_Plugins/ConditionalDisplayers/package.manifest
@@ -26,6 +26,24 @@
             "description": "Enter the aliases of the properties to show if the checkbox if unchecked (comma separated)",
             "key": "showIfUnchecked",
             "view": "textstring"
+          },
+          {
+            "label": "Show toggle labels",
+            "description": "Show labels next to toggle button.",
+            "key": "showLabels",
+            "view": "boolean"
+          },
+          {
+            "label": "Label On",
+            "description": "Label text when enabled.",
+            "key": "labelOn",
+            "view": "textstring"
+          },
+          {
+            "label": "Label Off",
+            "description": "Label text when disabled.",
+            "key": "labelOff",
+            "view": "textstring"
           }
         ]
       }

--- a/ConditionalDisplayers/App_Plugins/ConditionalDisplayers/propertyeditors/checkbox/checkbox.controller.js
+++ b/ConditionalDisplayers/App_Plugins/ConditionalDisplayers/propertyeditors/checkbox/checkbox.controller.js
@@ -9,8 +9,18 @@ function cdCheckboxController($scope, editorState, cdSharedLogic) {
         var parentPropertyAlias = $scope.model.alias.slice(0, -$scope.model.propertyAlias.length);
     }
 
+    // Define prevalues for labelOff and labelOn
+    $scope.labelOff = $scope.model.config.labelOff;
+    $scope.labelOn = $scope.model.config.labelOn;
+
+    // Set initial toggle label and visibility based on the showLabels config option
+    $scope.toggleLabel = $scope.model.config.showLabels ? $scope.labelOff : "";
+    $scope.showLabels = $scope.model.config.showLabels;
+
     $scope.clicked = function () {
         $scope.renderModel.value = !$scope.renderModel.value;
+        // Update the toggle label based on the new value
+        $scope.toggleLabel = $scope.showLabels ? ($scope.renderModel.value ? $scope.labelOn : $scope.labelOff) : "";
     };
 
     $scope.runDisplayLogic = function () {

--- a/ConditionalDisplayers/App_Plugins/ConditionalDisplayers/propertyeditors/checkbox/checkbox.html
+++ b/ConditionalDisplayers/App_Plugins/ConditionalDisplayers/propertyeditors/checkbox/checkbox.html
@@ -1,3 +1,3 @@
 ﻿<div class="umb-property-editor umb-boolean" ng-controller="Our.Umbraco.ConditionalDisplayers.CheckboxController">
-    <umb-toggle checked="renderModel.value" on-click="clicked()"></umb-toggle>
+    <uui-toggle ng-model="toggleValue" label="{{toggleLabel}}" labelPosition="right" ng-checked="renderModel.value===true" ng-on-change="clicked()"></uui-toggle>
 </div>


### PR DESCRIPTION
This PR addresses issue #10 and as a bonus (because I misread an old issue in the old repo - https://github.com/KOBENDigital/ConditionalDisplayers/issues/1), I thought the request was to use the UUI Component.

So by Accident, the Conditional Checkbox is now using the new UUI Component 😄.

**NOTE:** uui library is included by default in Umbraco 10.4 + and 11.1 + based on this post: https://umbraco.com/blog/umbraco-product-update-january-2023/

For previous versions of Umbraco that still support the uui, you will need to include or reference the library's css and js files manually.