### PR TITLE
Initial state and label bug fix

### DIFF
--- a/ConditionalDisplayers/App_Plugins/ConditionalDisplayers/propertyeditors/checkbox/checkbox.controller.js
+++ b/ConditionalDisplayers/App_Plugins/ConditionalDisplayers/propertyeditors/checkbox/checkbox.controller.js
@@ -46,7 +46,8 @@ function cdCheckboxController($scope, $element, editorState, cdSharedLogic) {
 
     var renderModelWatchUnsubscribe = $scope.$watch("renderModel.value", function (newVal) {
         $scope.model.value = newVal === true ? "1" : "0";
-
+        // Set Correct Label on first load
+        $scope.toggleLabel = $scope.showLabels ? ($scope.model.value === "1" ? $scope.labelOn : $scope.labelOff) : "";
         $scope.runDisplayLogic();
     });
 


### PR DESCRIPTION
If you enable the labels on checkbox and you set the initial state, on first load, the label will show the 'LabelOff' value, it should be set to the 'labelOn' instead.

This PR fixes this issue.