### PR TITLE
Proposing a simpler naming convention

### DIFF
--- a/ConditionalDisplayers/App_Plugins/ConditionalDisplayers/package.manifest
+++ b/ConditionalDisplayers/App_Plugins/ConditionalDisplayers/package.manifest
@@ -2,7 +2,7 @@
   "propertyEditors": [
     {
       "alias": "Our.Umbraco.CdCheckbox",
-      "name": "[Conditional Displayers] Conditional Checkbox",
+      "name": "[Conditional] Checkbox Displayer",
       "icon": "icon-checkbox-dotted-active",
       "group": "Conditional Displayers",
       "editor": {
@@ -51,7 +51,7 @@
     },
     {
       "alias": "Our.Umbraco.CdDropdownFlexible",
-      "name": "[Conditional Displayers] Conditional Dropdown",
+      "name": "[Conditional] Dropdown Displayer",
       "icon": "icon-filter-arrows",
       "group": "Conditional Displayers",
       "editor": {
@@ -76,7 +76,7 @@
     },
     {
       "alias": "Our.Umbraco.CdRadio",
-      "name": "[Conditional Displayers] Radio List",
+      "name": "[Conditional] Radio List Displayer",
       "icon": "icon-circle-dotted-active",
       "group": "Conditional Displayers",
       "editor": {
@@ -86,12 +86,13 @@
         "fields": [
           {
             "label": "Add prevalue",
-            "description": "Add, remove or sort values for the list.",
+            "description": "Add, remove or sort values for the conditional list.<br />*(multiple aliases must be comma separated without space)*",
             "key": "items",
             "view": "/App_Plugins/ConditionalDisplayers/prevalueeditors/cdMultivalues.html"
           },
           {
             "label": "Default value",
+            "description": "Type the value name from the list created above to be the initial default selection.<br/>*(Optional)*",
             "key": "default",
             "view": "textstring"
           }


### PR DESCRIPTION
I think we can simplify the naming convention of the Conditional displayer so it's easier to read, find and not take too much space.
_I will help out with documentations later and reduce the lengthy descriptions I added previously (for the time being I added matching description to the Radio List)_