### PR TITLE
Multivalues Prevalues UI Refinement

### DIFF
--- a/ConditionalDisplayers/App_Plugins/ConditionalDisplayers/cd.css
+++ b/ConditionalDisplayers/App_Plugins/ConditionalDisplayers/cd.css
@@ -1,30 +1,123 @@
-﻿
-.cd-prevalues-multivalues {
-    display: flex;
-    align-items: stretch;
+﻿.cd-prevalues-editor {
+    max-width: 800px;
+    width: 100%;
 }
 
-    .cd-prevalues-multivalues > div {
-        display: flex;
-        flex-direction: column;
-        justify-content: space-between;
-        margin-right: 0.8rem;
+    /* Need to declare parent to not affect other native properties */
+    .cd-prevalues-editor .cd-prevalues-multivalues__first {
+        width:180px;
     }
 
-
-    .cd-prevalues-multivalues input[type='text'] {
-        width: auto;
+    .cd-prevalues-editor .umb-prevalues-multivalues__left label {
+        font-size: 14px;
+        font-weight: 700;
+        /* 
+            * For smaller screens or if the the Tree is resized 
+            * Keeping things aligned nicely
+        */
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
     }
+        
+        .cd-prevalues-multivalues.umb-prevalues-multivalues__add {
+            margin-bottom: 10px;
+        }
 
-        .cd-prevalues-multivalues > div:last-child {
-            margin-right: 0;
+        .cd-prevalues-multivalues > .umb-prevalues-multivalues__left {
+            flex-direction: column;
+            margin-right: .8rem;
+        }
+
+        .cd-prevalues-multivalues > .umb-prevalues-multivalues__left input {
+            width: 100%;
         }
 
         .cd-prevalues-multivalues > div.align-bottom {
             align-self: flex-end;
         }
 
+        /* Calculated manually to match the same space used for Umbraco's native dropdown */
+        .cd-prevalues-multivalues.umb-prevalues-multivalues__add .umb-prevalues-multivalues__right {
+            margin-left: calc(45px - .8rem);
+        }
 
-    .cd-prevalues-multivalues .umb-node-preview__action{
-        cursor: pointer;
+        /* There is just a 1px difference but it is visible in high density screens */
+        .cd-prevalues-sortable .umb-prevalues-multivalues__right {
+            margin-left: calc(44px - .8rem);
+        }
+
+    .cd-prevalues-sortable i.icon {
+        cursor: move;
     }
+
+    .cd-prevalues-sortable .cd-prevalues-multivalues__first {
+        width: 154px;
+    }
+
+/* *** Breakpoints selected visually when the prevalues look ok *** */
+
+/* 
+    * 'Remove' button doesn't fit
+    * Target 'Add' as well to keep things consistent
+*/
+
+/* First, we drop them under the fields until they fit */
+@media only screen and (max-width: 528px) {
+
+    .cd-prevalue-wrap__first,
+    .cd-prevalue-wrap__last {
+        width: calc(50% - .4rem)
+    }
+
+    .cd-prevalue-wrap__first {
+        margin-right: .4rem !important;
+    }
+
+    .cd-prevalue-wrap__last {
+        margin-left: .4rem;
+        margin-right: 0 !important;
+    }
+
+    .cd-prevalues-editor .umb-prevalues-multivalues__right {
+        margin-top: .8rem;
+    }
+
+}
+
+/* Then, we remove the wide left margin to utilise the screen realestate */
+@media only screen and (max-width: 559px) {
+
+    /* Declare both to avoid over-using !important */
+    .cd-prevalues-multivalues.umb-prevalues-multivalues__add .umb-prevalues-multivalues__right,
+    .cd-prevalues-sortable .umb-prevalues-multivalues__right {
+        margin-left: 0;
+    }
+
+}
+
+/* Realign inputs up to this breakpoint */
+@media only screen and (max-width: 719px) {
+
+    .cd-prevalues-multivalues.umb-prevalues-multivalues__add,
+    .cd-prevalues-multivalues.umb-prevalues-multivalues__listitem {
+        flex-wrap: wrap;
+    }
+
+    /* Declare both to avoid over-using !important */
+    .cd-prevalues-editor .cd-prevalues-multivalues__first,
+    .cd-prevalues-sortable .cd-prevalues-multivalues__first {
+        margin: 0 0 .8rem;
+        width: 100%;
+    }
+
+    /* Align 'Add' button nicely to the right */
+    .cd-prevalues-multivalues.umb-prevalues-multivalues__add button {
+        margin-right: 0;
+    }
+
+    .cd-prevalues-multivalues i.icon {
+        margin-bottom: 5px;
+    }
+
+}

--- a/ConditionalDisplayers/App_Plugins/ConditionalDisplayers/prevalueeditors/cdMultivalues.html
+++ b/ConditionalDisplayers/App_Plugins/ConditionalDisplayers/prevalueeditors/cdMultivalues.html
@@ -1,36 +1,35 @@
 <div class="umb-property-editor umb-prevalues-multivalues cd-prevalues-editor" ng-controller="Our.Umbraco.ConditionalDisplayers.cdMultiValuesController">
-
-    <div class="control-group cd-prevalues-multivalues">
-        <div>
-            <strong>Value</strong>
+    <div class="control-group umb-prevalues-multivalues__add cd-prevalues-multivalues">
+        <div class="umb-prevalues-multivalues__left cd-prevalues-multivalues__first">
+            <label>Value</label>
             <input overlay-submit-on-enter="false" name="newItem" focus-when="{{focusOnNew}}" ng-keydown="createNew($event)" type="text" ng-model="newItem.value" val-highlight="{{hasError}}" />
         </div>
-        <div>
-            <strong>Show when selected</strong>
+        <div class="umb-prevalues-multivalues__left cd-prevalue-wrap__first">
+            <label>Show when selected</label>
             <input type="text" ng-model="newItem.show" val-server="item_{{$index}}" placeholder="Properties' aliases" />
         </div>
-        <div>
-            <strong>Hide when selected</strong>
+        <div class="umb-prevalues-multivalues__left cd-prevalue-wrap__last">
+            <label>Hide when selected</label>
             <input type="text" ng-model="newItem.hide" val-server="item_{{$index}}" placeholder="Properties' aliases" />
         </div>
-        <div class="align-bottom">
+        <div class="align-bottom umb-prevalues-multivalues__right">
             <button class="btn btn-info align-bottom" ng-click="add($event)">Add</button>
         </div>
     </div>
-    <div ui-sortable="sortableOptions" class="control-group">
-        <div class="cd-prevalues-multivalues control-group" ng-repeat="item in model.value">
+    <div ui-sortable="sortableOptions" class="control-group cd-prevalues-sortable">
+        <div class="control-group umb-prevalues-multivalues__listitem cd-prevalues-multivalues" ng-repeat="item in model.value">
             <i class="icon icon-navigation handle"></i>
-            <div>
+            <div class="umb-prevalues-multivalues__left cd-prevalues-multivalues__first">
                 <input type="text" ng-model="item.value" val-server="item_{{$index}}" />
             </div>
-            <div>
+            <div class="umb-prevalues-multivalues__left cd-prevalue-wrap__first">
                 <input type="text" ng-model="item.show" val-server="item_{{$index}}" placeholder="Properties' aliases" />
             </div>
-            <div>
+            <div class="umb-prevalues-multivalues__left cd-prevalue-wrap__last">
                 <input type="text" ng-model="item.hide" val-server="item_{{$index}}" placeholder="Properties' aliases" />
             </div>
-            <div class="align-bottom">
-                <a class="umb-node-preview__action" ng-click="remove(item, $event)">Remove</a>
+            <div class="umb-prevalues-multivalues__right">
+                <button class="umb-node-preview__action umb-node-preview__action--red" ng-click="remove(item, $event)">Remove</button>
             </div>
         </div>
     </div>


### PR DESCRIPTION
This PR adds some refinement to match Umbraco’s native Dropdown Prevalues as close as possible.

- Added class names to the main container and the sortable for direct targeting to the respective ‘.cd-prevalues-multivalues’
- Added Umbraco’s class names to container divs to use native styling
- Added other additional class names to take more control of alignment and small screens styling
- Allowed the main container to use all the available space and matched Umbraco’s native max-width
- Refined ‘Sub-labels’ container, font size (matching the property label) and font-weight so it’s not confusing visually
- Removed some styles that don’t have an affect anymore

_I left some comments in the CSS if you want to see what the additions are for, but they can be removed afterwards_