### PR TITLE
feat: add text value for multi language

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
       run: msbuild ${{ env.SOLUTION }} -p:Configuration=Release -p:GeneratePackageOnBuild=true -p:PackageOutputPath=${{ env.OUTPUT_PATH }}
 
     - name: Upload NuGet artifacts
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: nuget
         path: ${{ env.OUTPUT_PATH }}

--- a/ConditionalDisplayers/App_Plugins/ConditionalDisplayers/package.manifest
+++ b/ConditionalDisplayers/App_Plugins/ConditionalDisplayers/package.manifest
@@ -67,7 +67,7 @@
           },
           {
             "label": "Default value",
-            "description": "Type the value name from the list created above to be the initial default selection.<br/>*(Optional)*",
+            "description": "Type the text name from the list created above to be the initial default selection.<br/>Type the key value if key value was filled.<br/>*(Optional)*",
             "key": "default",
             "view": "textstring"
           }
@@ -92,7 +92,7 @@
           },
           {
             "label": "Default value",
-            "description": "Type the value name from the list created above to be the initial default selection.<br/>*(Optional)*",
+            "description": "Type the text name from the list created above to be the initial default selection.<br/>Type the key value if it was filled.<br/><br/>*(Optional)*",
             "key": "default",
             "view": "textstring"
           },

--- a/ConditionalDisplayers/App_Plugins/ConditionalDisplayers/prevalueeditors/cdMultivalues.controller.js
+++ b/ConditionalDisplayers/App_Plugins/ConditionalDisplayers/prevalueeditors/cdMultivalues.controller.js
@@ -1,12 +1,11 @@
 angular.module("umbraco").controller("Our.Umbraco.ConditionalDisplayers.cdMultiValuesController",
     function ($scope, $timeout) {
-
         //NOTE: We need to make each item an object, not just a string because you cannot 2-way bind to a primitive.
 
         $scope.newItem = {
             value: "",
             show: "",
-            hide:""
+            hide: ""
         };
         $scope.hasError = false;
         $scope.focusOnNew = false;
@@ -18,6 +17,7 @@ angular.module("umbraco").controller("Our.Umbraco.ConditionalDisplayers.cdMultiV
             for (var i in $scope.model.value) {
                 items.push({
                     value: $scope.model.value[i].value,
+                    key: $scope.model.value[i].key,
                     show: $scope.model.value[i].show,
                     hide: $scope.model.value[i].hide,
                     sortOrder: $scope.model.value[i].sortOrder,

--- a/ConditionalDisplayers/App_Plugins/ConditionalDisplayers/prevalueeditors/cdMultivalues.html
+++ b/ConditionalDisplayers/App_Plugins/ConditionalDisplayers/prevalueeditors/cdMultivalues.html
@@ -1,8 +1,12 @@
 <div class="umb-property-editor umb-prevalues-multivalues cd-prevalues-editor" ng-controller="Our.Umbraco.ConditionalDisplayers.cdMultiValuesController">
     <div class="control-group umb-prevalues-multivalues__add cd-prevalues-multivalues">
         <div class="umb-prevalues-multivalues__left cd-prevalues-multivalues__first">
-            <label>Value</label>
-            <input overlay-submit-on-enter="false" name="newItem" focus-when="{{focusOnNew}}" ng-keydown="createNew($event)" type="text" ng-model="newItem.value" val-highlight="{{hasError}}" />
+            <label>Text</label>
+            <input overlay-submit-on-enter="false" name="newItem" focus-when="{{focusOnNew}}" type="text" ng-model="newItem.value" val-highlight="{{hasError}}" />
+        </div>
+        <div class="umb-prevalues-multivalues__left cd-prevalues-multivalues__first">
+            <label>Key</label>
+            <input overlay-submit-on-enter="false" name="newItem" ng-keydown="createNew($event)" type="text" ng-model="newItem.key" val-highlight="{{hasError}}" />
         </div>
         <div class="umb-prevalues-multivalues__left cd-prevalue-wrap__first">
             <label>Show when selected</label>
@@ -21,6 +25,9 @@
             <i class="icon icon-navigation handle"></i>
             <div class="umb-prevalues-multivalues__left cd-prevalues-multivalues__first">
                 <input type="text" ng-model="item.value" val-server="item_{{$index}}" />
+            </div>
+            <div class="umb-prevalues-multivalues__left cd-prevalues-multivalues__first">
+                <input type="text" ng-model="item.key" val-server="item_{{$index}}" />
             </div>
             <div class="umb-prevalues-multivalues__left cd-prevalue-wrap__first">
                 <input type="text" ng-model="item.show" val-server="item_{{$index}}" placeholder="Properties' aliases" />

--- a/ConditionalDisplayers/App_Plugins/ConditionalDisplayers/propertyeditors/dropdownFlexible/dropdownFlexible.controller.js
+++ b/ConditionalDisplayers/App_Plugins/ConditionalDisplayers/propertyeditors/dropdownFlexible/dropdownFlexible.controller.js
@@ -34,7 +34,11 @@ angular.module("umbraco").controller("Our.Umbraco.ConditionalDisplayers.Dropdown
         $scope.runDisplayLogic = function () {
             if (editorState.current.ModelState) {
                 //init visible fields
-                var item = _.findWhere(config.items, { value: $scope.model.value });
+                //legacy
+                var itemByValue = _.findWhere(config.items, { value: $scope.model.value })
+                var itemBykey = _.findWhere(config.items, { key: $scope.model.value });
+                var item = itemByValue || itemBykey;
+
                 if (item) {
                     cdSharedLogic.displayProps(item.show, item.hide, parentPropertyAlias, parentBlockListItemId);
                 }

--- a/ConditionalDisplayers/App_Plugins/ConditionalDisplayers/propertyeditors/dropdownFlexible/dropdownFlexible.html
+++ b/ConditionalDisplayers/App_Plugins/ConditionalDisplayers/propertyeditors/dropdownFlexible/dropdownFlexible.html
@@ -4,7 +4,7 @@
             class="umb-property-editor umb-dropdown"
             ng-change="runDisplayLogic()"
             ng-model="model.value"
-            ng-options="item.value as item.value for item in model.config.items">
+            ng-options="(item.key || item.value) as item.value for item in model.config.items">
     </select>
 
 </div>

--- a/ConditionalDisplayers/App_Plugins/ConditionalDisplayers/propertyeditors/radio/radio.controller.js
+++ b/ConditionalDisplayers/App_Plugins/ConditionalDisplayers/propertyeditors/radio/radio.controller.js
@@ -27,11 +27,12 @@ angular.module("umbraco").controller("Our.Umbraco.ConditionalDisplayers.RadioCon
         $scope.model.value = $scope.model.config.default;
     }
 
-
     $scope.runDisplayLogic = function () {
         if (editorState.current.ModelState) {
             //init visible fields
-            var item = _.findWhere($scope.model.config.items, { value: $scope.model.value });
+            var itemByValue = _.findWhere($scope.model.config.items, { value: $scope.model.value })
+            var itemBykey = _.findWhere($scope.model.config.items, { key: $scope.model.value });
+            var item = itemByValue || itemBykey;
             if (item) {
                 cdSharedLogic.displayProps(item.show, item.hide, parentPropertyAlias, parentBlockListItemId);
             }
@@ -50,9 +51,8 @@ angular.module("umbraco").controller("Our.Umbraco.ConditionalDisplayers.RadioCon
             var vals = _.values($scope.model.config.items);
             var keys = _.keys($scope.model.config.items);
             for (var i = 0; i < vals.length; i++) {
-                $scope.viewItems.push({ key: keys[i], value: vals[i].value });
+                $scope.viewItems.push({ id: keys[i], value: vals[i].value, key: vals[i].key || vals[i].value });
             }
-
         }
 
         // Set the message to use for when a mandatory field isn't completed.

--- a/ConditionalDisplayers/App_Plugins/ConditionalDisplayers/propertyeditors/radio/radio.html
+++ b/ConditionalDisplayers/App_Plugins/ConditionalDisplayers/propertyeditors/radio/radio.html
@@ -2,9 +2,9 @@
     <ng-form name="radioButtonsFieldForm">
 
         <ul class="unstyled {{labelsPos}}" ng-class="{'cd-hrz-radio': model.config.alignHrz === '1', 'cd-btn-radio': model.config.asBtn === '1'}">
-            <li ng-repeat="item in viewItems track by item.key">
+            <li ng-repeat="item in viewItems track by item.id">
                 <umb-radiobutton name="{{model.alias}}_{{uniqueId}}"
-                                 value="{{item.value}}"
+                                 value="{{item.key}}"
                                  model="model.value"
                                  text="{{item.value}}"
                                  required="model.validation.mandatory && model.value == ''"


### PR DESCRIPTION
We user are PT-BR and the fields others datatypes as title ("título") was createds with that language.
I add a "key" field to recieved a back-end value and the "Value" received a label. In this commit I'm suggesting change the label to "Text" instead "Value".

The values already entered before this update will be maintained. If a value in the “key” field is added to an existing datatype, it will be prioritized.
In other words, anyone upgrading to this version will not need to add the “key” value.

![image](https://github.com/user-attachments/assets/73454ce9-1fdb-416f-b37a-8b9be82d9e24)

![image](https://github.com/user-attachments/assets/681ebc4f-617a-48d3-8f77-332c16cbad2f)
